### PR TITLE
Add dummy code for python , c/c++ and java in the IDE

### DIFF
--- a/views/ide.ejs
+++ b/views/ide.ejs
@@ -20,8 +20,7 @@
         <div id="ide-heading">CodeManiacs IDE</div>
         <div class="main-heading">
             <div class="submit-container">
-                <div id="editor">
-#include &#60;bits/stdc++.h&#62;
+                <div id="editor">#include &#60;bits/stdc++.h&#62;
 using namespace std;
 
 int main(){
@@ -104,8 +103,8 @@ int main(){
             var lang_enum = $(this).val();
             if (lang_enum == 10 || lang_enum == 4) {
                 editor.session.setMode("ace/mode/c_cpp");
-                var dummyc = 
-`#include bits/stdc++.h;
+                var dummycpp = 
+`#include <bits/stdc++.h>;
 using namespace std;
 
 int main(){
@@ -113,7 +112,17 @@ int main(){
 
     return 0;
 }`
-                editor.setValue(dummyc);
+                var dummyc = 
+`#include <stdio.h>;
+int main(void){
+    // Your code starts here
+
+    return 0;
+}`
+                if(lang_enum == 4)
+                    editor.setValue(dummyc);
+                else
+                    editor.setValue(dummycpp);
             }
             else if (lang_enum == 34 || lang_enum == 36) {
                 editor.session.setMode("ace/mode/python");
@@ -122,16 +131,10 @@ int main(){
             else if (lang_enum == 27) {
                 editor.session.setMode("ace/mode/java");
                 var dummyjava = 
-`import java.util.*;
-import java.lang.*;
-import java.io.*;
-
-class CodeManiacs
-{
-	public static void main (String[] args) throws java.lang.Exception
-	{
-		// your code goes here
-	}
+`public class Main {
+    public static void main(String[] args) {
+        System.out.println("hello, world");
+    }
 }`
                 editor.setValue(dummyjava);
             }

--- a/views/ide.ejs
+++ b/views/ide.ejs
@@ -104,12 +104,36 @@ int main(){
             var lang_enum = $(this).val();
             if (lang_enum == 10 || lang_enum == 4) {
                 editor.session.setMode("ace/mode/c_cpp");
+                var dummyc = 
+`#include bits/stdc++.h;
+using namespace std;
+
+int main(){
+    // Your code starts here
+
+    return 0;
+}`
+                editor.setValue(dummyc);
             }
             else if (lang_enum == 34 || lang_enum == 36) {
                 editor.session.setMode("ace/mode/python");
+                editor.setValue("#Your code here")
             }
             else if (lang_enum == 27) {
                 editor.session.setMode("ace/mode/java");
+                var dummyjava = 
+`import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class CodeManiacs
+{
+	public static void main (String[] args) throws java.lang.Exception
+	{
+		// your code goes here
+	}
+}`
+                editor.setValue(dummyjava);
             }
         });
     </script>

--- a/views/ide.ejs
+++ b/views/ide.ejs
@@ -104,7 +104,7 @@ int main(){
             if (lang_enum == 10 || lang_enum == 4) {
                 editor.session.setMode("ace/mode/c_cpp");
                 var dummycpp = 
-`#include <bits/stdc++.h>;
+`#include <bits/stdc++.h>
 using namespace std;
 
 int main(){
@@ -113,7 +113,7 @@ int main(){
     return 0;
 }`
                 var dummyc = 
-`#include <stdio.h>;
+`#include <stdio.h>
 int main(void){
     // Your code starts here
 


### PR DESCRIPTION
Earlier the ide only showed hardcoded cpp code, no matter what langauge was selected. Now it shows dummy code of that particular language which is selected
Solves #78 


[C / C++]
![Screenshot from 2020-10-29 02-55-12](https://user-images.githubusercontent.com/21126219/97498470-42b4d900-1992-11eb-9103-5aea768e9bc4.png)
[Python3 / Python2]
![Screenshot from 2020-10-29 02-55-27](https://user-images.githubusercontent.com/21126219/97498476-45afc980-1992-11eb-900c-8e9a924ec776.png)
[Java]
![Screenshot from 2020-10-29 02-55-42](https://user-images.githubusercontent.com/21126219/97498479-48122380-1992-11eb-9acc-4e14cd725b2e.png)

@dheeraj135 
