### PR TITLE
Fixed delete button size

### DIFF
--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -58,7 +58,7 @@
                             <form method="POST" action="/admin/dlt_prob/<%= data[i].qID %>">
                                 <a href="/admin/edit/<%= data[i].qID %>"><button type="button"
                                         class="btn btn-success btn-sm">EDIT</button></a>
-                                <button type="submit" class="btn btn-danger btn-xs">DELETE</button>
+                                <button type="submit" class="btn btn-danger btn-sm">DELETE</button>
                             </form>
                         </td>
                     </tr>


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

# Fixed the issue #145 

# The class of the DELETE button was btn-xs, hence changed it to btn-sm, so that it looks uniform with the EDIT button.

![image](https://user-images.githubusercontent.com/63646834/101278809-ec825380-37e3-11eb-87f9-bbffa5e1177a.png)


