### PR TITLE
Bug: Problem id pointing to the particular problem

### DIFF
--- a/views/submission_subID.ejs
+++ b/views/submission_subID.ejs
@@ -40,7 +40,7 @@
                 <tr>
                     <td><%= data.subID %></td>
                     <td><%= locals.user.username %></td>
-                    <td><a href="<%= data.qID %>"><%= data.qID %></a></td>
+                    <td><a href="http://localhost:3000/problem/<%= data.qID %>"><%= data.qID %></a></td>
                     <td><%= data.language %></td>
                     <% var status_color = "nonAC_txt" %>
                     <% if (data.verdict === "Accepted") status_color = "AC_txt" %>


### PR DESCRIPTION
**Fixes #156**

**Changes Proposed**
The problem id in the table should point to the particular problem.

**My Solution**
Now on clicking the id number, the page redirects to the particular problem. Though the link I used is localhost, it should be changed once the application is in production.